### PR TITLE
Use log prior to prevent under/overflow

### DIFF
--- a/examples/testTmcmcNew.jl
+++ b/examples/testTmcmcNew.jl
@@ -4,7 +4,7 @@ using TransitionalMCMC
 lb  = -15
 ub  = 15
 
-fT(x) = pdf(Uniform(lb,ub), x[1,:]) .* pdf(Uniform(lb,ub), x[2,:])
+fT(x) = logpdf(Uniform(lb,ub), x[1,:]) .+ logpdf(Uniform(lb,ub), x[2,:])
 sample_fT(Nsamples) = rand(Uniform(lb,ub), Nsamples, 2)
 
 log_fD_T(x) = log.(pdf(MvNormal([0,0],[1 -0.5; -0.5 1]), x) + pdf(MvNormal([5,5],[1 0.5; 0.5 1]), x) + pdf(MvNormal([-5,5],[1 0.9; 0.9 1]), x))

--- a/src/tmcmc.jl
+++ b/src/tmcmc.jl
@@ -21,7 +21,7 @@
 #
 ###
 
-function tmcmc(log_fD_T, fT, sample_fT, Nsamples, burnin=20, thin=3, beta2=0.01)
+function tmcmc(log_fD_T, log_fT, sample_fT, Nsamples, burnin=20, thin=3, beta2=0.01)
 
     j1 = 0;                     # Iteration number
     βj = 0;                     # Tempering parameter
@@ -95,9 +95,9 @@ function tmcmc(log_fD_T, fT, sample_fT, Nsamples, burnin=20, thin=3, beta2=0.01)
         # Ensure that cov is symetric
         SIGMA_j = (SIGMA_j' + SIGMA_j) / 2
 
-        prop = mu -> proprnd(mu, SIGMA_j, fT)           # Anonymous function for proposal
+        prop = mu -> proprnd(mu, SIGMA_j, x -> exp.(log_fT(x)))           # Anonymous function for proposal
 
-        target = x -> log_fD_T(x) .* βj1 .+ log.(fT(x)) # Anonymous function for transitional distribution
+        target = x -> log_fD_T(x) .* βj1 .+ log_fT(x) # Anonymous function for transitional distribution
 
         # Weighted resampling of θj (indecies with replacement)
         randIndex = sample(1:Nsamples, Weights(wn_j), Nsamples, replace=true)
@@ -150,6 +150,3 @@ function runChains2(target, prop, θ_js, burnin, thin)
     return θ_j1, α
 
 end
-
-
-


### PR DESCRIPTION
Hi @AnderGray , what do you think of using the log-prior instead of the pdf? It should be a little more stable, and it seems nice IMO to parallel the log-likelihood. Here's a tiny PR to make this change. The result won't be compatible, so if you like the idea the README will need to be updated. This is also a breaking change so the version would need to be changed accordingly.