### PR TITLE
Use CovarianceEstimation.jl

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -4,6 +4,7 @@ authors = ["Ander Gray <ander.gray@liverpool.ac.uk>", "Adolphus Lye <Adolphus.Ly
 version = "0.3.0"
 
 [deps]
+CovarianceEstimation = "587fd27a-f159-11e8-2dae-1979310e6154"
 Distributed = "8ba89e20-285c-5b6f-9357-94700520ee1b"
 Distributions = "31c24e10-a181-5473-b8eb-7969acd0382f"
 Logging = "56ddb016-857b-54e1-b83d-db4d58db5568"
@@ -11,6 +12,7 @@ StatsBase = "2913bbd2-ae8a-5f71-8c99-4fb6c76f3a91"
 TimerOutputs = "a759f4b9-e2f1-59dc-863e-4aeb61b1ea8f"
 
 [compat]
+CovarianceEstimation = "0.2.5"
 Distributions = "0.24"
 StatsBase = "0.33"
 TimerOutputs = "0.5"

--- a/src/TransitionalMCMC.jl
+++ b/src/TransitionalMCMC.jl
@@ -22,7 +22,7 @@
 ###
 module TransitionalMCMC
 
-using Distributed, StatsBase, Distributions, Logging
+using Distributed, StatsBase, Distributions, Logging, CovarianceEstimation
 
 export tmcmc, metropolis_hastings, metropolis_hastings_simple
 

--- a/src/mcmc.jl
+++ b/src/mcmc.jl
@@ -72,7 +72,7 @@ end
 function metropolis_hastings_simple(
     Target::Function,
     PropRnd::Function,
-    start::Vector{<:Real},
+    start::AbstractVector{<:Real},
     Nsamples::Integer,
     burnin::Integer=50,
     thin::Integer=3)

--- a/src/tmcmc.jl
+++ b/src/tmcmc.jl
@@ -42,7 +42,7 @@ function tmcmc(
 
     Ndims = size(θ_j, 2)         # Number of dimensions (input)
 
-    covariance_method = LinearShrinkage(DiagonalCommonVariance()) # * DiagonalCommonVariance is always SPD!
+    covariance_method = LinearShrinkage(DiagonalUnequalVariance()) # * DiagonalUnequalVariance is always SPD!
 
     @timeit_debug to "Main while loop" while βj < 1
 

--- a/test/tmcmc.jl
+++ b/test/tmcmc.jl
@@ -71,7 +71,7 @@
         # Log Likelihood
         logLik(x) = -1 * ((x[1]^2 + x[2] - 11)^2 + (x[1] + x[2]^2 - 7)^2)
 
-        samps, acc = tmcmc(logLik, logprior, priorRnd, 10000)
+        samps, acc = tmcmc(logLik, logprior, priorRnd, 15000)
 
         μ = mean(samps, dims=1) |> vec
         σ = std(samps, dims=1) |> vec
@@ -104,7 +104,7 @@
 
         end
 
-        Nsamples = 10000
+        Nsamples = 15000
 
         samps, acc = tmcmc(logLik, logprior, priorRnd, Nsamples)
 

--- a/test/tmcmc.jl
+++ b/test/tmcmc.jl
@@ -71,7 +71,7 @@
         # Log Likelihood
         logLik(x) = -1 * ((x[1]^2 + x[2] - 11)^2 + (x[1] + x[2]^2 - 7)^2)
 
-        samps, acc = tmcmc(logLik, logprior, priorRnd, 15000)
+        samps, acc = tmcmc(logLik, logprior, priorRnd, 20000)
 
         μ = mean(samps, dims=1) |> vec
         σ = std(samps, dims=1) |> vec
@@ -104,7 +104,7 @@
 
         end
 
-        Nsamples = 15000
+        Nsamples = 20000
 
         samps, acc = tmcmc(logLik, logprior, priorRnd, Nsamples)
 


### PR DESCRIPTION
Using the package enables us to always estimate invertible covariance
matrices for the proposal distribution during the MCMC step.

I also extracted the bisection method estimating beta and the weights to
clean up the code.