### PR TITLE
TimerOutputs + some speedups

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -8,8 +8,10 @@ Distributed = "8ba89e20-285c-5b6f-9357-94700520ee1b"
 Distributions = "31c24e10-a181-5473-b8eb-7969acd0382f"
 Logging = "56ddb016-857b-54e1-b83d-db4d58db5568"
 StatsBase = "2913bbd2-ae8a-5f71-8c99-4fb6c76f3a91"
+TimerOutputs = "a759f4b9-e2f1-59dc-863e-4aeb61b1ea8f"
 
 [compat]
-StatsBase = "0.33"
 Distributions = "0.24"
+StatsBase = "0.33"
+TimerOutputs = "0.5"
 julia = "1"

--- a/src/mcmc.jl
+++ b/src/mcmc.jl
@@ -78,29 +78,29 @@ function metropolis_hastings_simple(
     thin::Integer=3)
 
     dims = length(start)                                    # Dimensions of input/ prior
-    chain = zeros(Nsamples * thin + burnin, dims)
-    chain[1, :] = start[:]
+    chain = zeros(dims, Nsamples * thin + burnin)
+    chain[:, 1] = start[:]
     accRate = 0
 
     for i = 2:( Nsamples * thin + burnin)
 
-        next = PropRnd(chain[i - 1, :])                 # Draw candidate
+        next = PropRnd(chain[:, i - 1])                 # Draw candidate
 
         targDen = Target(next)[1]                    # Target Density at next sample
-        targPrevious = Target(chain[i - 1, :])[1]       # Target Density at current sample
+        targPrevious = Target(chain[:, i - 1])[1]       # Target Density at current sample
 
         α =  min(0, targDen - targPrevious)
 
         accepted = α >= log(rand())
 
         if accepted
-            chain[i, :] = next
+            chain[:, i] = next
             accRate = accRate + 1
         else
-            chain[i, :] = chain[i - 1, :]
+            chain[:, i] = chain[:, i - 1]
         end
 
     end
     accRate = accRate / (Nsamples * thin + burnin)
-    return chain[burnin + 1:thin:end, :], accRate
+    return chain[:, burnin + 1:thin:end]', accRate
 end


### PR DESCRIPTION
It looks like there are some places things could be a little faster. This PR adds some `@timeit_debug` calls from `TimerOutputs`. I've used the results from this to start on speeding things up. Here are the results after my updates:
```
 ───────────────────────────────────────────────────────────────────────────────
                                        Time                   Allocations      
                                ──────────────────────   ───────────────────────
        Tot / % measured:            3.71s / 17.0%            473MiB / 100%     

 Section                ncalls     time   %tot     avg     alloc   %tot      avg
 ───────────────────────────────────────────────────────────────────────────────
 Main while loop             1    633ms   100%   633ms    472MiB  100%    472MiB
   Run chains                3    444ms  70.2%   148ms    163MiB  34.4%  54.2MiB
   Compute covariance        3    161ms  25.4%  53.5ms    281MiB  59.6%  93.8MiB
     Update Σ_j              3    161ms  25.4%  53.5ms    281MiB  59.6%  93.8MiB
     Symmetrize Σ_j          3   64.4μs  0.01%  21.5μs      720B  0.00%     240B
     Inititialize Σ_j        3   6.63μs  0.00%  2.21μs     0.00B  0.00%    0.00B
   Initialize ins            3   2.79ms  0.44%   929μs    913KiB  0.19%   304KiB
   Update ins                3   2.24ms  0.35%   747μs   0.96MiB  0.20%   329KiB
   Inner while loop          3   1.34ms  0.21%   446μs   1.10MiB  0.23%   375KiB
   Compute randIndex         3    222μs  0.04%  74.1μs    236KiB  0.05%  78.8KiB
   Nominal weights           3   82.6μs  0.01%  27.5μs   47.9KiB  0.01%  16.0KiB
   Weighted mean             3   41.8μs  0.01%  13.9μs   47.4KiB  0.01%  15.8KiB
   Normalised weights        3   36.4μs  0.01%  12.1μs   47.5KiB  0.01%  15.8KiB
   Log evidence              3   17.7μs  0.00%  5.88μs      240B  0.00%    80.0B
 ───────────────────────────────────────────────────────────────────────────────
```

By far the most expensive operations are the "Run chains" and "Compute covariance" sections. I made the following changes:

1. In `metropolis_hastings_simple`, the original implementation was traversing across rows. In Julia, memory is organized columnwise, so it's much faster to iterate column-first. Rather than reorganize the code around this, I just swapped the indices in the function and returned the transpose.
2. To avoid allocations, I initialized `Σ_j` outside the loop. Then the loop can just update in-place. There's still a lot of overhead in this section:
```julia
 @timeit_debug to "Update Σ_j" for l = 1:Nsamples
     Σ_j .+= beta2 .* wn_j[l] .* (θ_j[l,:]' .- Th_wm)' * (θ_j[l,:]' .- Th_wm)
end
```
I'm sure this can still be reduced a lot. But rather than change too much at once, I wanted to see if you had any feedback on updatges so far.