### PR TITLE
Implement proper 1D functionality for metropolis hastings

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,8 +9,8 @@ jobs:
     strategy:
       matrix:
         version:
-          - '1.5'
-          - '1.6'
+          - "1.6"
+          - "1.7"
         os:
           - ubuntu-latest
         arch:

--- a/examples/Nd_gaussians.jl
+++ b/examples/Nd_gaussians.jl
@@ -1,25 +1,23 @@
 using Distributed, StatsBase
 
-addprocs(4, exeflags="--project")
+addprocs(4; exeflags="--project")
 @everywhere begin
-
     using TransitionalMCMC, Distributions, LinearAlgebra
     Ndims = 5
     # Prior Bounds
-    lb, ub  = -10, 10
+    lb, ub = -10, 10
 
     mean1 = ones(Ndims) * 5
     mean2 = ones(Ndims) * (-5)
-    
-    cov = 1* Matrix(I, Ndims, Ndims)
+
+    cov = 1 * Matrix(I, Ndims, Ndims)
 
     # Prior Density and sampler
-    logprior(x) = sum(logpdf(Uniform.(lb, ub), x))
+    logprior(x) = sum(logpdf.(Uniform(lb, ub), x))
     priorRnd(Nsamples) = rand(Uniform(lb, ub), Nsamples, Ndims)
 
     # Log Likelihood
     logLik(x) = log.(pdf(MvNormal(mean1, cov), x) + pdf(MvNormal(mean2, cov), x))
-
 end
 
 Nsamples = 1000

--- a/test/mcmc.jl
+++ b/test/mcmc.jl
@@ -1,13 +1,11 @@
 @testset "Metropolis Hastings general" begin
-
     @testset "1D" begin
         Random.seed!(123456)
-        prop(mu) = MvNormal(mu, 3)
+        prop(mu) = Normal(mu, 3)
 
-        target(x) = log(pdf(MvNormal([2], 1), x))
+        target(x) = log(pdf(Normal(2, 1), x))
 
-
-        samps, acc = metropolis_hastings(target, prop, [2], 2000, 200)
+        samps, acc = metropolis_hastings(target, prop, 2.0, 2000, 200)
 
         @test mean(samps) ≈ 2 atol = 0.1
         @test std(samps) ≈ 1 atol = 0.1
@@ -21,8 +19,8 @@
 
         samps, acc = metropolis_hastings(target, prop, [-2, 2, 0], 2000, 200)
 
-        μ = mean(samps, dims = 1)
-        σ = std(samps, dims = 1)
+        μ = mean(samps; dims=1)
+        σ = std(samps; dims=1)
         corrs = cor(samps)
         @test vec(μ) ≈ [-2; 2; 0] atol = 0.2
         @test vec(σ) ≈ [1; 1; 1] atol = 0.1
@@ -35,10 +33,12 @@
 
         target(x) = pdf(MvNormal([-2, 2, 0], [1 0.5 0.5; 0.5 1 0.5; 0.5 0.5 1]), x)
 
-        samps, acc = metropolis_hastings(target, prop, [-2, 2, 0], 2000, 200, islogged = false)
+        samps, acc = metropolis_hastings(
+            target, prop, [-2, 2, 0], 2000, 200; islogged=false
+        )
 
-        μ = mean(samps, dims = 1)
-        σ = std(samps, dims = 1)
+        μ = mean(samps; dims=1)
+        σ = std(samps; dims=1)
         corrs = cor(samps)
         @test vec(μ) ≈ [-2; 2; 0] atol = 0.2
         @test vec(σ) ≈ [1; 1; 1] atol = 0.1
@@ -46,20 +46,17 @@
     end
 end
 
-
 @testset "Metropolis Hastings simple" begin
-
     @testset "1D" begin
         Random.seed!(123456)
-        proprnd(mu) = rand(MvNormal(mu, 3))
+        proprnd(mu) = rand(Normal(mu, 3))
 
-        target(x) = log(pdf(MvNormal([2], 1), x))
+        target(x) = log(pdf(Normal(2, 1), x))
 
-        samps, acc = metropolis_hastings_simple(target, proprnd, [2], 2000, 200)
+        samps, acc = metropolis_hastings_simple(target, proprnd, 2, 2000, 200)
 
         @test mean(samps) ≈ 2 atol = 0.1
         @test std(samps) ≈ 1 atol = 0.1
-
     end
 
     @testset "3D" begin
@@ -68,15 +65,15 @@ end
 
         target(x) = log(pdf(MvNormal([-2, 2, 0], [1 0.5 0.5; 0.5 1 0.5; 0.5 0.5 1]), x))
 
-        samps, acc = metropolis_hastings_simple(target, proprnd, [-2,2, 0], 2000, 200)
+        samps, acc = metropolis_hastings_simple(target, proprnd, [-2, 2, 0], 2000, 200)
 
-        μ = mean(samps, dims = 1)
-        σ = std(samps, dims = 1)
+        μ = mean(samps; dims=1)
+        σ = std(samps; dims=1)
         corrs = cor(samps)
+
         @test vec(μ) ≈ [-2; 2; 0] atol = 0.2
         @test vec(σ) ≈ [1; 1; 1] atol = 0.1
         @test corrs ≈ [1 0.5 0.5; 0.5 1 0.5; 0.5 0.5 1] atol = 0.2
-
     end
     Random.seed!()
 end

--- a/test/tmcmc.jl
+++ b/test/tmcmc.jl
@@ -1,25 +1,28 @@
 @testset "TransitionalMCMC" begin
-
     disable_logging(Logging.Info)
 
     @testset "1D" begin
         Random.seed!(123456)
-        lb, ub  = -15, 15
+        lb, ub = -15, 15
 
         μ = [0 5]
         σ = [1 0.2]
         w = [0.7 0.3]
 
-        fT(x) = logpdf(Uniform(lb, ub), x[1])
-        sample_fT(Nsamples) = rand(Uniform(lb, ub), Nsamples, 1)
+        fT(x) = logpdf(Uniform(lb, ub), x)
+        sample_fT(Nsamples) = rand(Uniform(lb, ub), Nsamples)
 
-        log_fD_T(x) = log(w[1] * pdf(Normal(μ[1], σ[1]), x[1]) + w[2] * pdf(Normal(μ[2], σ[2]), x[1]))
+        function log_fD_T(x)
+            return log(
+                w[1] * pdf(Normal(μ[1], σ[1]), x[1]) + w[2] * pdf(Normal(μ[2], σ[2]), x[1])
+            )
+        end
 
         Nsamples = 1000
         X, _ = tmcmc(log_fD_T, fT, sample_fT, Nsamples)
 
         m = sum(w .* μ)
-        s = sqrt(sum(w .* (σ.^2 + μ.^2 .- m^2)))
+        s = sqrt(sum(w .* (σ .^ 2 + μ .^ 2 .- m^2)))
 
         h0 = ExactOneSampleKSTest(vec(X), Normal(m, s))
 
@@ -29,7 +32,7 @@
     @testset "2D" begin
         Random.seed!(1234)
 
-        lb, ub  = -15, 15
+        lb, ub = -15, 15
 
         w = [0.6, 0.4]
         μ = [0 5; 0 5]
@@ -38,7 +41,7 @@
         Σ2 = [1 0.5; 0.5 1]
 
         # Compute mean and cov of resulting gaussian mixture
-        m = sum(w .* μ, dims=2) |> vec
+        m = vec(sum(w .* μ; dims=2))
         C = w[1] * Σ1 + w[2] * Σ2
         C += w[1] * (μ[:, 1] - m) * (μ[:, 1] - m)'
         C += w[2] * (μ[:, 2] - m) * (μ[:, 2] - m)'
@@ -49,7 +52,11 @@
         fT(x) = logpdf(Uniform(lb, ub), x[1]) .+ logpdf(Uniform(lb, ub), x[2])
         sample_fT(Nsamples) = rand(Uniform(lb, ub), Nsamples, 2)
 
-        log_fD_T(x) = log.(w[1] * pdf(MvNormal(μ[:, 1], Σ1), x) + w[2] * pdf(MvNormal(μ[:, 2], Σ2), x))
+        function log_fD_T(x)
+            return log.(
+                w[1] * pdf(MvNormal(μ[:, 1], Σ1), x) + w[2] * pdf(MvNormal(μ[:, 2], Σ2), x)
+            )
+        end
 
         X, _ = tmcmc(log_fD_T, fT, sample_fT, Nsamples)
 
@@ -62,7 +69,7 @@
 
     @testset "Himmelblau" begin
         Random.seed!(123456)
-        lb, ub  = -5, 5
+        lb, ub = -5, 5
 
         # Prior Density and sampler
         logprior(x) = logpdf(Uniform(lb, ub), x[1]) + logpdf(Uniform(lb, ub), x[2])
@@ -73,8 +80,8 @@
 
         samps, acc = tmcmc(logLik, logprior, priorRnd, 20000)
 
-        μ = mean(samps, dims=1) |> vec
-        σ = std(samps, dims=1) |> vec
+        μ = vec(mean(samps; dims=1))
+        σ = vec(std(samps; dims=1))
         corrs = cor(samps)
 
         # Reference values obtained using 1e7 samples
@@ -83,33 +90,30 @@
         @test corrs ≈ [1.0 0; 0 1.0] atol = 0.1 # independent
     end
 
-
     @testset "Himmelblau parallel" begin
         addprocs(2; exeflags="--project")
         @everywhere begin
-
             using TransitionalMCMC, Distributions, Random
 
             Random.seed!(123456)
 
             # Prior Bounds
-            lb, ub  = -5, 5
+            lb, ub = -5, 5
 
             # Prior Density and sampler
             logprior(x) = logpdf(Uniform(lb, ub), x[1]) + logpdf(Uniform(lb, ub), x[2])
             priorRnd(Nsamples) = rand(Uniform(lb, ub), Nsamples, 2)
 
             # Log Likelihood
-            logLik(x) = -1 * ((x[1]^2 + x[2] - 11)^2 + (x[1] + x[2]^2 - 7).^2)
-
+            logLik(x) = -1 * ((x[1]^2 + x[2] - 11)^2 + (x[1] + x[2]^2 - 7) .^ 2)
         end
 
         Nsamples = 20000
 
         samps, acc = tmcmc(logLik, logprior, priorRnd, Nsamples)
 
-        μ = mean(samps, dims=1) |> vec
-        σ = std(samps, dims=1) |> vec
+        μ = vec(mean(samps; dims=1))
+        σ = vec(std(samps; dims=1))
         corrs = cor(samps)
 
         # Reference values obtained using 1e7 samples


### PR DESCRIPTION
Because vectors were used internally for metropolis hastings (simple) passing to 1D functions did not work as intended. This implements some checks on the dimensions to ensure scalars/vectors are passed to the functions as required.

I adapted the tests accordingly.

A lot of the other changes are just the formatter doing its thing.